### PR TITLE
implements handOut

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -6,6 +6,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "ccapndave/elm-flat-map": "1.2.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.4",
             "elm/html": "1.0.0",

--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.4",
             "elm/html": "1.0.0",
             "elm/random": "1.0.0",
-            "sudo-rushil/elm-cards": "3.1.0"
+            "sudo-rushil/elm-cards": "3.2.0"
         },
         "indirect": {
             "elm/json": "1.1.2",

--- a/src/MagicTrick.elm
+++ b/src/MagicTrick.elm
@@ -1,7 +1,9 @@
-module MagicTrick exposing (handOut, Game, mergeGame, UserSelection(..))
+module MagicTrick exposing (handOut, Game, mergeGame, UserSelection(..), readMind)
 import Deck exposing (..)
 import Cards exposing (Card(..))
 import List
+import Cards exposing (Card)
+import CardRepresentation exposing (cardName)
 
 type alias Game = { left:  ShuffledDeck
                   , center: ShuffledDeck
@@ -41,3 +43,17 @@ mergeGame selection game =
             UserTookLeft -> newDeck (listOfCenter game ++ listOfLeft game ++ listOfRight game)
             UserTookRight -> newDeck (listOfLeft game ++ listOfRight game ++ listOfCenter game)
             UserTookCenter -> newDeck (listOfLeft game ++ listOfCenter game ++ listOfRight game)
+
+readMind : ShuffledDeck -> Card
+readMind deck =
+    let
+       div : Int -> Int -> Int
+       div a b = floor (toFloat a / toFloat b)
+
+       listOfCards = getCards deck
+
+       indexToPick = div (List.length listOfCards) 2
+    in
+       case List.drop indexToPick (List.take (indexToPick+1) listOfCards) of
+            [] -> Back
+            pick :: _ -> pick

--- a/src/MagicTrick.elm
+++ b/src/MagicTrick.elm
@@ -1,0 +1,72 @@
+module MagicTrick exposing (handOut, Game)
+import Deck exposing (..)
+import Main exposing (Msg(..))
+import Deck exposing (ShuffledDeck(..))
+import Cards exposing (Card(..))
+import List
+
+type alias Game = { left:  ShuffledDeck
+                  , center: ShuffledDeck
+                  , right: ShuffledDeck
+                  }
+
+emptyDeck: ShuffledDeck
+emptyDeck = newDeck []
+-- implement appendLeft appendCenter and appendRight
+-- pass that function to handOutRecursivly
+-- 
+-- appendLeft: Card -> Game -> Game
+-- appendLeft card game = { game | left = appendCard card (.left game)}
+
+-- appendCenter: Card -> Game -> Game
+-- appendCenter card game = { game | center = appendCard card (.center game)}
+
+-- appendRight: Card -> Game -> Game
+-- appendRight card game = { game | left = appendCard card (.left game)}
+
+-- type GameDeck = Left | Center | Right
+
+-- handOutRecursivly: (Game, ShuffledDeck, GameDeck)-> (Game, ShuffledDeck, GameDeck)
+-- handOutRecursivly gameState =
+--     let 
+--         (game, deck, gamedeck) = gameState
+--         (nextCard, restDeck) = draw deck
+--     in
+--         case nextCard of
+--            Back -> (game, restDeck, Left)
+--            _ -> 
+--                 case gamedeck of
+--                     Left -> (appendLeft nextCard game, restDeck, Center)
+--                     Center -> (appendCenter nextCard game, restDeck, Right)
+--                     Right -> (appendRight nextCard game, restDeck, Left)
+
+-- handOut : ShuffledDeck -> Game
+-- handOut deck = 
+--     let
+--         (game, _, _) = handOutRecursivly 
+--             ( { left = emptyDeck
+--               , center = emptyDeck
+--               , right = emptyDeck 
+--               }
+--             , deck
+--             , Left
+--             )
+--     in
+--         game
+cardOfTuple: (Int, Card) -> Card
+cardOfTuple (index, card) = card
+
+isNthOf: Int -> (Int, a) -> Bool
+isNthOf n (index, _) = n == modBy 3 index
+
+toIndexedCard: Int -> Card -> (Int, Card)
+toIndexedCard index card = (index, card)
+handOut : ShuffledDeck -> Game
+handOut deck =
+    let
+        indexedCards = List.indexedMap toIndexedCard (getCards deck)
+    in
+    { left = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 0) indexedCards))
+    , center = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 1) indexedCards))
+    , right = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 2) indexedCards))
+    }

--- a/src/MagicTrick.elm
+++ b/src/MagicTrick.elm
@@ -1,7 +1,5 @@
-module MagicTrick exposing (handOut, Game)
+module MagicTrick exposing (handOut, Game, mergeGame, UserSelection(..))
 import Deck exposing (..)
-import Main exposing (Msg(..))
-import Deck exposing (ShuffledDeck(..))
 import Cards exposing (Card(..))
 import List
 
@@ -12,49 +10,9 @@ type alias Game = { left:  ShuffledDeck
 
 emptyDeck: ShuffledDeck
 emptyDeck = newDeck []
--- implement appendLeft appendCenter and appendRight
--- pass that function to handOutRecursivly
--- 
--- appendLeft: Card -> Game -> Game
--- appendLeft card game = { game | left = appendCard card (.left game)}
 
--- appendCenter: Card -> Game -> Game
--- appendCenter card game = { game | center = appendCard card (.center game)}
-
--- appendRight: Card -> Game -> Game
--- appendRight card game = { game | left = appendCard card (.left game)}
-
--- type GameDeck = Left | Center | Right
-
--- handOutRecursivly: (Game, ShuffledDeck, GameDeck)-> (Game, ShuffledDeck, GameDeck)
--- handOutRecursivly gameState =
---     let 
---         (game, deck, gamedeck) = gameState
---         (nextCard, restDeck) = draw deck
---     in
---         case nextCard of
---            Back -> (game, restDeck, Left)
---            _ -> 
---                 case gamedeck of
---                     Left -> (appendLeft nextCard game, restDeck, Center)
---                     Center -> (appendCenter nextCard game, restDeck, Right)
---                     Right -> (appendRight nextCard game, restDeck, Left)
-
--- handOut : ShuffledDeck -> Game
--- handOut deck = 
---     let
---         (game, _, _) = handOutRecursivly 
---             ( { left = emptyDeck
---               , center = emptyDeck
---               , right = emptyDeck 
---               }
---             , deck
---             , Left
---             )
---     in
---         game
 cardOfTuple: (Int, Card) -> Card
-cardOfTuple (index, card) = card
+cardOfTuple (_, card) = card
 
 isNthOf: Int -> (Int, a) -> Bool
 isNthOf n (index, _) = n == modBy 3 index
@@ -70,3 +28,16 @@ handOut deck =
     , center = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 1) indexedCards))
     , right = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 2) indexedCards))
     }
+
+type UserSelection = UserTookLeft | UserTookCenter | UserTookRight
+mergeGame : UserSelection -> Game -> ShuffledDeck
+mergeGame selection game = 
+    let
+        listOfLeft = .left >> getCards
+        listOfCenter = .center >> getCards
+        listOfRight = .right >> getCards
+    in
+        case selection of
+            UserTookLeft -> newDeck (listOfCenter game ++ listOfLeft game ++ listOfRight game)
+            UserTookRight -> newDeck (listOfLeft game ++ listOfRight game ++ listOfCenter game)
+            UserTookCenter -> newDeck (listOfLeft game ++ listOfCenter game ++ listOfRight game)

--- a/src/MagicTrick.elm
+++ b/src/MagicTrick.elm
@@ -25,10 +25,14 @@ handOut : ShuffledDeck -> Game
 handOut deck =
     let
         indexedCards = List.indexedMap toIndexedCard (getCards deck)
+        everyFirst = 0 |> isNthOf
+        everySecond = 1 |> isNthOf
+        everyThird = 2 |> isNthOf
+
     in
-    { left = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 0) indexedCards))
-    , center = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 1) indexedCards))
-    , right = newDeck (List.map cardOfTuple (List.filter (isNthOf <| 2) indexedCards))
+    { left = indexedCards |> List.filter everyFirst |> List.map cardOfTuple |> newDeck
+    , center = indexedCards |> List.filter everySecond |> List.map cardOfTuple |> newDeck
+    , right = indexedCards |> List.filter everyThird |> List.map cardOfTuple |> newDeck
     }
 
 type UserSelection = UserTookLeft | UserTookCenter | UserTookRight

--- a/tests/MagicTrickTests.elm
+++ b/tests/MagicTrickTests.elm
@@ -5,11 +5,11 @@ import Expect
 
 import Cards exposing (..)
 import Deck exposing (..)
+import CardRepresentation exposing (cardName)
 
-import MagicTrick exposing (handOut, Game, mergeGame, UserSelection(..))
+import MagicTrick exposing (handOut, Game, mergeGame, UserSelection(..), readMind)
 import List
-import Cards exposing (Face(..), Suit(..))
-import Deck exposing (ShuffledDeck(..))
+import Cards exposing (Face(..))
 
 deckSize: ShuffledDeck -> Int
 deckSize = getCards >> List.length
@@ -155,4 +155,38 @@ all =
                     in
                         mergeGame UserTookLeft game |> Expect.equal expectedDeck
             ]
+        , describe "readMind" <|
+            List.map (\(deck, card) -> test ("should pick " ++ (viewCard >> Tuple.second) card) <|
+                \_ -> readMind (newDeck deck) |> Expect.equal card)
+                    [ ( [ Card Hearts Ace
+                        , Card Spades Ace
+                        , Card Clubs Ace
+                        ]
+                        , Card Spades Ace
+                        )
+                    , ( [ Card Spades Ace
+                        , Card Spades King
+                        , Card Spades Queen
+                        , Card Hearts Ace
+                        , Card Hearts King
+                        , Card Hearts Queen
+                        , Card Clubs Ace
+                        , Card Clubs King
+                        , Card Clubs Queen
+                        ]
+                      , Card Hearts King
+                      )
+                    , ( []
+                      , Back
+                      )
+                    , ( [ Card Hearts Ace
+                        , Card Hearts King
+                        , Card Hearts Queen
+                        , Card Spades Ace
+                        , Card Spades King
+                        , Card Spades Queen
+                        ]
+                      , Card Hearts Queen
+                      )
+                    ]
         ]

--- a/tests/MagicTrickTests.elm
+++ b/tests/MagicTrickTests.elm
@@ -7,157 +7,172 @@ import Cards exposing (..)
 import Deck exposing (..)
 import CardRepresentation exposing (cardName)
 
-import MagicTrick exposing (handOut, Game, mergeGame, UserSelection(..), readMind)
+import MagicTrick exposing (Game, UserSelection(..), ProperSizedDeck, SlicedDeck(..), length, downSize, handOut, mergeGame, readMind)
 import List
 import Cards exposing (Face(..))
+import Maybe.FlatMap exposing (flatMap)
 
-deckSize: ShuffledDeck -> Int
-deckSize = getCards >> List.length
+-- deckSize: ProperSizedDeck -> Int
+-- deckSize = getCards >> List.length
 
-leftSize: Game -> Int
-leftSize = .left >> deckSize
+-- leftSize: Game -> Int
+-- leftSize = .left >> deckSize
 
-centerSize: Game -> Int
-centerSize = .center >> deckSize
+-- centerSize: Game -> Int
+-- centerSize = .center >> deckSize
 
-rightSize: Game -> Int
-rightSize = .center >> deckSize
+-- rightSize: Game -> Int
+-- rightSize = .center >> deckSize
 
-emptyDeck: ShuffledDeck
-emptyDeck = newDeck []
+-- emptyDeck: ProperSizedDeck
+-- emptyDeck = ProperSizedDeck newDeck []
 
 all : Test
 all = 
     describe "MagicTrick"
-        [ describe "handOut"
-            [ test "should return a list of three decks" <|
-                \_ -> 
-                    handOut emptyDeck |> Expect.all 
-                        [ \result -> leftSize result |> Expect.equal 0
-                        , \result -> centerSize result |> Expect.equal 0
-                        , \result -> rightSize result |> Expect.equal 0
-                        ]
-            , test "should split shuffledDeck up to three decks" <|
+        [ describe "downSize"
+            [ test "should return Nothing for absurd number of cards" <|
+                \_ ->
+                    let 
+                        absurdSizedDeck = []
+                    in
+                        downSize absurdSizedDeck |> Expect.equal Nothing
+            
+            , test "should not change the size of a proper sized" <|
                 \_ ->
                     let
-                        deckOfThree = newDeck 
+                        rightSizedDeck = [ Card Hearts Ace
+                                         , Card Spades Ace
+                                         , Card Clubs Ace
+                                         ]
+                        properSizedDeck = downSize rightSizedDeck
+                    in
+                        Maybe.map MagicTrick.length properSizedDeck |> Expect.equal (Just 3)
+
+            , test "should change the size of invalid sized deck" <|
+                \_ ->
+                    let
+                        invalidSizedDeck = [ Card Hearts Ace, Card Spades Ace, Card Clubs Ace
+                                           , Card Hearts King, Card Spades King, Card Clubs King
+                                           , Card Hearts Queen, Card Spades Queen, Card Clubs Queen
+                                           , Card Hearts Jack, Card Spades Jack, Card Clubs Jack
+                                           ]
+                        properSizedDeck = downSize invalidSizedDeck
+                    in
+                        Maybe.map MagicTrick.length properSizedDeck |> Expect.equal (Just 9)
+                        
+            ]
+         , describe "handOut"
+            [ test "should split shuffledDeck up to three decks" <|
+                \_ ->
+                    let
+                        deckOfThree = 
                             [ Card Hearts Ace
                             , Card Spades Ace
                             , Card Clubs Ace
-                            ]
+                            ] |> downSize
                     in
-                        handOut deckOfThree |> Expect.all
-                            [ \result -> .left result |> Expect.equal ([Card Hearts Ace] |> newDeck)
-                            , \result -> .center result |> Expect.equal ([Card Spades Ace] |> newDeck)
-                            , \result -> .right result |> Expect.equal ([Card Clubs Ace] |> newDeck)
-                            ]               
+                        Maybe.map handOut deckOfThree |> Expect.all
+                            [ \result -> Maybe.map .left result |> Expect.equal ([Card Hearts Ace] |> SlicedDeck |> Just)
+                            , \result -> Maybe.map .center result |> Expect.equal ([Card Spades Ace] |> SlicedDeck |> Just)
+                            , \result -> Maybe.map .right result |> Expect.equal ([Card Clubs Ace] |> SlicedDeck |> Just)
+                            ]
             , test "should split deck of nine up to three decks with three" <|
                 \_ ->
                     let
-                        deckOfThree = newDeck 
+                        deckOfNine = downSize
                             [ Card Hearts Ace, Card Hearts King, Card Hearts Queen
                             , Card Spades Ace, Card Spades King, Card Spades Queen
                             , Card Clubs Ace, Card Clubs King, Card Clubs Queen
                             ]
-                        expectedLeft = [Card Hearts Ace, Card Spades Ace, Card Clubs Ace] |> newDeck
-                        expectedCenter = [Card Hearts King, Card Spades King, Card Clubs King] |> newDeck
-                        expectedRight = [Card Hearts Queen, Card Spades Queen, Card Clubs Queen] |> newDeck
+                        expectedLeft = [Card Hearts Ace, Card Spades Ace, Card Clubs Ace] |> SlicedDeck |> Just
+                        expectedCenter = [Card Hearts King, Card Spades King, Card Clubs King] |> SlicedDeck |> Just
+                        expectedRight = [Card Hearts Queen, Card Spades Queen, Card Clubs Queen] |> SlicedDeck |> Just
                     in
-                        handOut deckOfThree |> Expect.all
-                            [ \result -> .left result |> Expect.equal (expectedLeft)
-                            , \result -> .center result |> Expect.equal (expectedCenter)
-                            , \result -> .right result |> Expect.equal (expectedRight)
+                        Maybe.map handOut deckOfNine |> Expect.all
+                            [ \result -> Maybe.map .left result |> Expect.equal expectedLeft
+                            , \result -> Maybe.map .center result |> Expect.equal expectedCenter
+                            , \result -> Maybe.map .right result |> Expect.equal expectedRight
                             ]
             ]
         , describe "mergeGame"
-            [ test "should merge an empty game to a empty deck" <|
-                \_ ->
-                    let 
-                        emptyGame = 
-                            { left = emptyDeck
-                            , center = emptyDeck
-                            , right = emptyDeck
-                            }
-                    in
-                        mergeGame UserTookLeft emptyGame |> Expect.equal (newDeck [])
-
-            , test "should merge left deck into middle when user selects left" <|
+            [  test "should merge left deck into middle when user selects left" <|
                 \_ ->
                     let
-                        game = { left = newDeck [Card Hearts Ace]
-                               , center = newDeck [Card Spades Ace]
-                               , right = newDeck [Card Clubs Ace]
+                        game = { left = [Card Hearts Ace] |> SlicedDeck
+                               , center = [Card Spades Ace] |> SlicedDeck
+                               , right = [Card Clubs Ace] |> SlicedDeck
                                }
-                        expectedDeck = newDeck [ Card Spades Ace
-                                               , Card Hearts Ace
-                                               , Card Clubs Ace
-                                               ]
+                        expectedDeck = [ Card Spades Ace
+                                       , Card Hearts Ace
+                                       , Card Clubs Ace
+                                       ] |> downSize
                     in
                         mergeGame UserTookLeft game |> Expect.equal expectedDeck
            
             , test "should merge right deck into middle when user selects r" <|
                 \_ ->
                     let
-                        game = { left = newDeck [Card Hearts Ace]
-                               , center = newDeck [Card Spades Ace]
-                               , right = newDeck [Card Clubs Ace]
+                        game = { left = [Card Hearts Ace] |> SlicedDeck
+                               , center = [Card Spades Ace] |> SlicedDeck
+                               , right = [Card Clubs Ace] |> SlicedDeck
                                }
-                        expectedDeck = newDeck [ Card Hearts Ace
-                                               , Card Clubs Ace
-                                               , Card Spades Ace
-                                               ]
+                        expectedDeck = [ Card Hearts Ace
+                                       , Card Clubs Ace
+                                       , Card Spades Ace
+                                       ] |> downSize
                     in
                         mergeGame UserTookRight game |> Expect.equal expectedDeck
            
             , test "should merge center deck into middle when user selects center" <|
                 \_ ->
                     let
-                        game = { left = newDeck [Card Hearts Ace]
-                               , center = newDeck [Card Spades Ace]
-                               , right = newDeck [Card Clubs Ace]
+                        game = { left = [Card Hearts Ace] |> SlicedDeck
+                               , center = [Card Spades Ace] |> SlicedDeck
+                               , right = [Card Clubs Ace] |> SlicedDeck
                                }
-                        expectedDeck = newDeck [ Card Hearts Ace
-                                               , Card Spades Ace
-                                               , Card Clubs Ace
-                                               ]
+                        expectedDeck = [ Card Hearts Ace
+                                       , Card Spades Ace
+                                       , Card Clubs Ace
+                                       ] |> downSize
                     in
                         mergeGame UserTookCenter game |> Expect.equal expectedDeck
                                    
             , test "should merge a deck of nine cards" <|
                 \_ ->
                     let
-                        game = { left = newDeck 
+                        game = { left = 
                                     [ Card Hearts Ace
                                     , Card Hearts King
                                     , Card Hearts Queen
-                                    ]
-                               , center = newDeck 
+                                    ] |> SlicedDeck
+                               , center =
                                     [ Card Spades Ace
                                     , Card Spades King
                                     , Card Spades Queen
-                                    ]
-                               , right = newDeck 
+                                    ] |> SlicedDeck
+                               , right =
                                     [ Card Clubs Ace
                                     , Card Clubs King
                                     , Card Clubs Queen
-                                    ]
+                                    ] |> SlicedDeck
                                }
-                        expectedDeck = newDeck [ Card Spades Ace
-                                               , Card Spades King
-                                               , Card Spades Queen
-                                               , Card Hearts Ace
-                                               , Card Hearts King
-                                               , Card Hearts Queen
-                                               , Card Clubs Ace
-                                               , Card Clubs King
-                                               , Card Clubs Queen
-                                               ]
+                        expectedDeck = [ Card Spades Ace
+                                       , Card Spades King
+                                       , Card Spades Queen
+                                       , Card Hearts Ace
+                                       , Card Hearts King
+                                       , Card Hearts Queen
+                                       , Card Clubs Ace
+                                       , Card Clubs King
+                                       , Card Clubs Queen
+                                       ] |> downSize
                     in
                         mergeGame UserTookLeft game |> Expect.equal expectedDeck
             ]
         , describe "readMind" <|
             List.map (\(deck, card) -> test ("should pick " ++ (viewCard >> Tuple.second) card) <|
-                \_ -> readMind (newDeck deck) |> Expect.equal card)
+                \_ -> flatMap readMind (downSize deck) |> Expect.equal (Just card))
                     [ ( [ Card Hearts Ace
                         , Card Spades Ace
                         , Card Clubs Ace
@@ -175,9 +190,6 @@ all =
                         , Card Clubs Queen
                         ]
                       , Card Hearts King
-                      )
-                    , ( []
-                      , Back
                       )
                     -- , ( [ Card Hearts Ace
                     --     , Card Hearts King

--- a/tests/MagicTrickTests.elm
+++ b/tests/MagicTrickTests.elm
@@ -6,11 +6,10 @@ import Expect
 import Cards exposing (..)
 import Deck exposing (..)
 
-import MagicTrick exposing (handOut, Game)
+import MagicTrick exposing (handOut, Game, mergeGame, UserSelection(..))
 import List
+import Cards exposing (Face(..), Suit(..))
 import Deck exposing (ShuffledDeck(..))
-import Cards exposing (Face(..))
-import Cards exposing (Suit(..))
 
 deckSize: ShuffledDeck -> Int
 deckSize = getCards >> List.length
@@ -24,20 +23,20 @@ centerSize = .center >> deckSize
 rightSize: Game -> Int
 rightSize = .center >> deckSize
 
+emptyDeck: ShuffledDeck
+emptyDeck = newDeck []
+
 all : Test
 all = 
     describe "MagicTrick"
         [ describe "handOut"
             [ test "should return a list of three decks" <|
                 \_ -> 
-                    let
-                        emptyDeck = Deck.take 0 Deck.fullDeck
-                    in
-                        handOut emptyDeck |> Expect.all 
-                            [ \result -> leftSize result |> Expect.equal 0
-                            , \result -> centerSize result |> Expect.equal 0
-                            , \result -> rightSize result |> Expect.equal 0
-                            ]
+                    handOut emptyDeck |> Expect.all 
+                        [ \result -> leftSize result |> Expect.equal 0
+                        , \result -> centerSize result |> Expect.equal 0
+                        , \result -> rightSize result |> Expect.equal 0
+                        ]
             , test "should split shuffledDeck up to three decks" <|
                 \_ ->
                     let
@@ -69,5 +68,91 @@ all =
                             , \result -> .center result |> Expect.equal (expectedCenter)
                             , \result -> .right result |> Expect.equal (expectedRight)
                             ]
+            ]
+        , describe "mergeGame"
+            [ test "should merge an empty game to a empty deck" <|
+                \_ ->
+                    let 
+                        emptyGame = 
+                            { left = emptyDeck
+                            , center = emptyDeck
+                            , right = emptyDeck
+                            }
+                    in
+                        mergeGame UserTookLeft emptyGame |> Expect.equal (newDeck [])
+
+            , test "should merge left deck into middle when user selects left" <|
+                \_ ->
+                    let
+                        game = { left = newDeck [Card Hearts Ace]
+                               , center = newDeck [Card Spades Ace]
+                               , right = newDeck [Card Clubs Ace]
+                               }
+                        expectedDeck = newDeck [ Card Spades Ace
+                                               , Card Hearts Ace
+                                               , Card Clubs Ace
+                                               ]
+                    in
+                        mergeGame UserTookLeft game |> Expect.equal expectedDeck
+           
+            , test "should merge right deck into middle when user selects r" <|
+                \_ ->
+                    let
+                        game = { left = newDeck [Card Hearts Ace]
+                               , center = newDeck [Card Spades Ace]
+                               , right = newDeck [Card Clubs Ace]
+                               }
+                        expectedDeck = newDeck [ Card Hearts Ace
+                                               , Card Clubs Ace
+                                               , Card Spades Ace
+                                               ]
+                    in
+                        mergeGame UserTookRight game |> Expect.equal expectedDeck
+           
+            , test "should merge center deck into middle when user selects center" <|
+                \_ ->
+                    let
+                        game = { left = newDeck [Card Hearts Ace]
+                               , center = newDeck [Card Spades Ace]
+                               , right = newDeck [Card Clubs Ace]
+                               }
+                        expectedDeck = newDeck [ Card Hearts Ace
+                                               , Card Spades Ace
+                                               , Card Clubs Ace
+                                               ]
+                    in
+                        mergeGame UserTookCenter game |> Expect.equal expectedDeck
+                                   
+            , test "should merge a deck of nine cards" <|
+                \_ ->
+                    let
+                        game = { left = newDeck 
+                                    [ Card Hearts Ace
+                                    , Card Hearts King
+                                    , Card Hearts Queen
+                                    ]
+                               , center = newDeck 
+                                    [ Card Spades Ace
+                                    , Card Spades King
+                                    , Card Spades Queen
+                                    ]
+                               , right = newDeck 
+                                    [ Card Clubs Ace
+                                    , Card Clubs King
+                                    , Card Clubs Queen
+                                    ]
+                               }
+                        expectedDeck = newDeck [ Card Spades Ace
+                                               , Card Spades King
+                                               , Card Spades Queen
+                                               , Card Hearts Ace
+                                               , Card Hearts King
+                                               , Card Hearts Queen
+                                               , Card Clubs Ace
+                                               , Card Clubs King
+                                               , Card Clubs Queen
+                                               ]
+                    in
+                        mergeGame UserTookLeft game |> Expect.equal expectedDeck
             ]
         ]

--- a/tests/MagicTrickTests.elm
+++ b/tests/MagicTrickTests.elm
@@ -1,0 +1,73 @@
+module MagicTrickTests exposing (..)
+
+import Test exposing (..)
+import Expect
+
+import Cards exposing (..)
+import Deck exposing (..)
+
+import MagicTrick exposing (handOut, Game)
+import List
+import Deck exposing (ShuffledDeck(..))
+import Cards exposing (Face(..))
+import Cards exposing (Suit(..))
+
+deckSize: ShuffledDeck -> Int
+deckSize = getCards >> List.length
+
+leftSize: Game -> Int
+leftSize = .left >> deckSize
+
+centerSize: Game -> Int
+centerSize = .center >> deckSize
+
+rightSize: Game -> Int
+rightSize = .center >> deckSize
+
+all : Test
+all = 
+    describe "MagicTrick"
+        [ describe "handOut"
+            [ test "should return a list of three decks" <|
+                \_ -> 
+                    let
+                        emptyDeck = Deck.take 0 Deck.fullDeck
+                    in
+                        handOut emptyDeck |> Expect.all 
+                            [ \result -> leftSize result |> Expect.equal 0
+                            , \result -> centerSize result |> Expect.equal 0
+                            , \result -> rightSize result |> Expect.equal 0
+                            ]
+            , test "should split shuffledDeck up to three decks" <|
+                \_ ->
+                    let
+                        deckOfThree = newDeck 
+                            [ Card Hearts Ace
+                            , Card Spades Ace
+                            , Card Clubs Ace
+                            ]
+                    in
+                        handOut deckOfThree |> Expect.all
+                            [ \result -> .left result |> Expect.equal ([Card Hearts Ace] |> newDeck)
+                            , \result -> .center result |> Expect.equal ([Card Spades Ace] |> newDeck)
+                            , \result -> .right result |> Expect.equal ([Card Clubs Ace] |> newDeck)
+                            ]               
+            , test "should split deck of nine up to three decks with three" <|
+                \_ ->
+                    let
+                        deckOfThree = newDeck 
+                            [ Card Hearts Ace, Card Hearts King, Card Hearts Queen
+                            , Card Spades Ace, Card Spades King, Card Spades Queen
+                            , Card Clubs Ace, Card Clubs King, Card Clubs Queen
+                            ]
+                        expectedLeft = [Card Hearts Ace, Card Spades Ace, Card Clubs Ace] |> newDeck
+                        expectedCenter = [Card Hearts King, Card Spades King, Card Clubs King] |> newDeck
+                        expectedRight = [Card Hearts Queen, Card Spades Queen, Card Clubs Queen] |> newDeck
+                    in
+                        handOut deckOfThree |> Expect.all
+                            [ \result -> .left result |> Expect.equal (expectedLeft)
+                            , \result -> .center result |> Expect.equal (expectedCenter)
+                            , \result -> .right result |> Expect.equal (expectedRight)
+                            ]
+            ]
+        ]

--- a/tests/MagicTrickTests.elm
+++ b/tests/MagicTrickTests.elm
@@ -179,14 +179,14 @@ all =
                     , ( []
                       , Back
                       )
-                    , ( [ Card Hearts Ace
-                        , Card Hearts King
-                        , Card Hearts Queen
-                        , Card Spades Ace
-                        , Card Spades King
-                        , Card Spades Queen
-                        ]
-                      , Card Hearts Queen
-                      )
+                    -- , ( [ Card Hearts Ace
+                    --     , Card Hearts King
+                    --     , Card Hearts Queen
+                    --     , Card Spades Ace
+                    --     , Card Spades King
+                    --     , Card Spades Queen
+                    --     ]
+                    --   , Card Hearts Queen
+                    --   )
                     ]
         ]


### PR DESCRIPTION
Hallo Patrick,

bitte diesen PR noch nicht mergen - hier fehlt noch die Funktion um die ausgeteilten Karten wieder zu einem neuen  Stapel zusammen zu mergen.

Ich hab zuerst versucht eine andere Lösung als du zu wählen und möglichst die ganze Zeit bei dem Typus des ShuffledDecks zu bleiben. Aber das macht das Handling sehr kompliziert was meine Versuche in den Zeilen 15-55 zeigen.

Dabe steht in der Docucon Elm-Cards noch drin, man solle möglichst nicht ein Deck in eine Liste umwandeln. Ich frage mich woher man weiß ab wann man die Typsicherheit eines proprietären Typs verlassen soll und wann es ok ist auf einen generischeren Typ zu wechseln.