### PR TITLE
Magic trick

### DIFF
--- a/src/MagicTrick.elm
+++ b/src/MagicTrick.elm
@@ -1,10 +1,9 @@
 module MagicTrick exposing ( Game, UserSelection(..), ProperSizedDeck, SlicedDeck(..)
-                           , length, downSize, handOut, mergeGame, readMind, createProperSizedDeck
+                           , length, downSize, handOut, mergeGame, mergeGame2, readMind, createProperSizedDeck
                            )
 import Cards exposing (Card(..), Face(..), Suit(..))
-import List exposing (..)
-import CardRepresentation exposing (cardName)
-import Html.Attributes exposing (multiple)
+import List
+-- import CardRepresentation exposing (cardName)
 import Array
 import Result
 
@@ -17,6 +16,8 @@ type alias Deck = List Card
 
 type ProperSizedDeck = ProperSizedDeck Deck
 type SlicedDeck = SlicedDeck Deck
+
+
 
 type UserSelection = UserTookLeft | UserTookCenter | UserTookRight
 
@@ -56,7 +57,7 @@ downSize shuffledDeck =
             0 -> Nothing
             1 -> Nothing
             2 -> Nothing
-            _ -> shuffledDeck |> take amount |> ProperSizedDeck |> Just
+            _ -> shuffledDeck |> List.take amount |> ProperSizedDeck |> Just
     in
         shuffledDeck |> List.take amount
 
@@ -98,6 +99,9 @@ handOut deck =
     , right = indexedCards |> List.filter everyThird |> List.map cardOfTuple |> SlicedDeck
     }
 
+-- Das Problem ist, dass merge selber wieder ein Result zurück gibt. 
+-- Dadurch kommt es zu einem Result Result...
+-- Wo müsste also ein Result.andThen zum einsatz kommen?
 mergeGame : UserSelection -> Game -> Result String ProperSizedDeck
 mergeGame selection game =
     let
@@ -109,6 +113,20 @@ mergeGame selection game =
             UserTookLeft -> (listOfCenter game ++ listOfLeft game ++ listOfRight game) |> createProperSizedDeck
             UserTookRight -> (listOfLeft game ++ listOfRight game ++ listOfCenter game) |> createProperSizedDeck
             UserTookCenter -> (listOfLeft game ++ listOfCenter game ++ listOfRight game) |> createProperSizedDeck
+
+
+
+mergeGame2 : UserSelection -> Game -> ProperSizedDeck
+mergeGame2 selection game =
+    let
+        listOfLeft = .left >> unwrapSlicedDeck
+        listOfCenter = .center >> unwrapSlicedDeck
+        listOfRight = .right >> unwrapSlicedDeck
+    in
+        case selection of
+            UserTookLeft -> (listOfCenter game ++ listOfLeft game ++ listOfRight game) |> ProperSizedDeck
+            UserTookRight -> (listOfLeft game ++ listOfRight game ++ listOfCenter game) |> ProperSizedDeck
+            UserTookCenter -> (listOfLeft game ++ listOfCenter game ++ listOfRight game) |> ProperSizedDeck
 
 readMind : ProperSizedDeck -> Maybe Card
 readMind deck =

--- a/src/MagicTrick.elm
+++ b/src/MagicTrick.elm
@@ -1,16 +1,24 @@
 module MagicTrick exposing ( Game, UserSelection(..), ProperSizedDeck, SlicedDeck(..)
                            , length, downSize, handOut, mergeGame, mergeGame2, readMind, createProperSizedDeck
+                           , representProperSizedDeck, representGame
                            )
 import Cards exposing (Card(..), Face(..), Suit(..))
 import List
--- import CardRepresentation exposing (cardName)
+import CardRepresentation exposing (cardName)
 import Array
 import Result
+
 
 type alias Game = { left:  SlicedDeck
                   , center: SlicedDeck
                   , right: SlicedDeck
                   }
+
+type alias RepresentativeGame = { left: List String
+                                , center: List String
+                                , right: List String
+                                }
+
 
 type alias Deck = List Card
 
@@ -80,6 +88,15 @@ div a b = floor (toFloat a / toFloat b)
 unwrapProperSizedDeck : ProperSizedDeck -> List Card
 unwrapProperSizedDeck deck = case deck of
    ProperSizedDeck d -> d
+
+representProperSizedDeck : ProperSizedDeck -> List String
+representProperSizedDeck deck = deck |> unwrapProperSizedDeck |> List.map cardName
+
+representGame: Game -> RepresentativeGame
+representGame game = { left = game |> .left |> unwrapSlicedDeck |> List.map cardName
+                     , center = game |> .center |> unwrapSlicedDeck |> List.map cardName
+                     , right = game |> .right |> unwrapSlicedDeck |> List.map cardName
+                     }
 
 unwrapSlicedDeck : SlicedDeck -> List Card
 unwrapSlicedDeck deck = case deck of

--- a/src/MockUser.elm
+++ b/src/MockUser.elm
@@ -1,0 +1,19 @@
+module MockUser exposing (selectDeck)
+
+import Cards exposing (Card(..))
+
+import MagicTrick exposing (UserSelection(..), Game, SlicedDeck(..))
+
+findCard: Card -> SlicedDeck -> Bool
+findCard cardToFind slicedDeck =  case slicedDeck of
+    SlicedDeck d -> List.member cardToFind d
+
+
+selectDeck: Card -> Game -> UserSelection
+selectDeck card game =
+    if game |> .left |> findCard card then
+        UserTookLeft
+    else if game |> .center |> findCard card then
+        UserTookCenter
+    else
+        UserTookRight

--- a/tests/FuzzMagicTrickTests.elm
+++ b/tests/FuzzMagicTrickTests.elm
@@ -1,0 +1,93 @@
+module FuzzMagicTrickTests exposing (..)
+
+import Expect
+import Fuzz exposing (..)
+import Test exposing (..)
+import Test exposing (Test)
+import MagicTrick exposing (ProperSizedDeck)
+import Deck exposing (ShuffledDeck)
+import Debug exposing (log)
+import Cards exposing (Card(..), Face(..), Suit(..))
+import List exposing (..)
+import Cards exposing (..)
+import Deck exposing (fullDeck, getCards)
+import CardRepresentation exposing (cardName)
+import Array
+import MagicTrick exposing (createProperSizedDeck, handOut, SlicedDeck(..), Game, UserSelection(..), mergeGame2, representProperSizedDeck, representGame, readMind)
+import Expect exposing (true)
+import Html exposing (a)
+
+mergeGame = mergeGame2
+
+regularUsageTests: Test
+regularUsageTests =
+        describe "valid Game"
+            [ fuzz (intRange 0 21) "should find card" <|
+                \randomCardIndex ->
+                    let
+                        wantOutput = False
+                        log : String -> a -> a
+                        log msg a = if wantOutput 
+                            then Debug.log msg a
+                            else a
+
+                        findCard: Card -> SlicedDeck -> Bool
+                        findCard cardToFind slicedDeck =  case slicedDeck of
+                           SlicedDeck d -> List.member cardToFind d
+
+                        -- Is it valid to support an Else-Branch? There was a bug in findCard that
+                        simulateUser: Card -> Game -> UserSelection
+                        simulateUser card game =
+                            if game |> .left |> findCard card then
+                                UserTookLeft
+                            else if game |> .center |> findCard card then
+                                UserTookCenter
+                            else if game |> .right |> findCard card then
+                                UserTookRight
+                            else
+                                log "Did not find card anywhere" UserTookRight
+
+                        simulateRound: Int -> Card -> Result String ProperSizedDeck -> Result String ProperSizedDeck
+                        simulateRound roundNr memorizedCard properSizedDeck =
+                            let
+                                roundLabel = (Debug.toString roundNr)
+                                y10 = log ("Deck " ++ roundLabel) (Result.map representProperSizedDeck properSizedDeck)
+
+                                round = Result.map handOut properSizedDeck
+                                y20 = log ("Round " ++ roundLabel) (Result.map representGame round)
+
+                                choice = Result.map (simulateUser memorizedCard) round
+                                y30 = log ("Choice " ++ roundLabel) choice
+
+                                result = Result.map2 mergeGame choice round
+                                y40 = log ("Resulting Deck after Round " ++ roundLabel) (Result.map representProperSizedDeck result)
+                            in
+                                result
+
+
+                        x00 = log "***********************************" True
+                        deck = fullDeck |> getCards |> List.take 21 
+
+                        memorized = case Array.get randomCardIndex (Array.fromList deck) of
+                           Just card -> card
+                           Nothing -> Card Spades Ace
+
+
+                        x03 = log "Initial random number" randomCardIndex
+                        x05 = log "Memorized Card " (cardName memorized)
+
+                        checkedDeck = createProperSizedDeck deck
+                        
+                        secondDeck = simulateRound 1 memorized checkedDeck
+
+                        thirdDeck = simulateRound 2 memorized secondDeck
+
+                        fourthDeck = simulateRound 3 memorized thirdDeck
+
+                        readCard = case Result.map readMind fourthDeck of
+                           Ok card -> card
+                           Err msg -> log msg (Just Back)
+                        x10 = log "Identified Card " (Maybe.map cardName readCard)
+                    in
+                        readCard |> Expect.equal (Just memorized)
+            ]

--- a/tests/MagicTrickIntegrationTests.elm
+++ b/tests/MagicTrickIntegrationTests.elm
@@ -1,0 +1,44 @@
+module MagicTrickIntegrationTests exposing (..)
+
+import Test exposing (..)
+import Expect 
+import MagicTrick exposing (createProperSizedDeck)
+import Cards exposing (Face(..))
+import MagicTrick exposing (Game, SlicedDeck(..), UserSelection(..), ProperSizedDeck, mergeGame2)
+import Cards exposing (Card (..), Suit(..), Face(..))
+
+
+all: Test
+all =
+    describe "MagicTrick Integration"
+        [ describe "merge"
+            [ test "should return the simple Result a round" <|
+                \_ ->
+                    let
+                        game = Result.Ok { left = SlicedDeck [Card Spades Ace]
+                                         , center = SlicedDeck [Card Hearts Ace]
+                                         , right = SlicedDeck [Card Clubs Ace]
+                                         }
+                        selection =  Result.Ok UserTookLeft
+                        expectedMergedDeck = createProperSizedDeck [ Card Hearts Ace
+                                                                   , Card Spades Ace
+                                                                   , Card Clubs Ace
+                                                                   ]
+                        
+                        join : Result x (Result x a) -> Result x a
+                        join mx =
+                            case mx of
+                                Ok x ->
+                                    x
+
+                                Err err ->
+                                    Err err
+
+                        
+                        result1 = Result.map2 mergeGame2 selection game
+                        -- result = join result1
+
+                    in
+                    Expect.equal expectedMergedDeck result1
+            ]
+        ]

--- a/tests/MockUserTests.elm
+++ b/tests/MockUserTests.elm
@@ -1,0 +1,46 @@
+module MockUserTests exposing (..)
+
+import Test exposing (..)
+import Expect 
+import MagicTrick exposing (Game, SlicedDeck(..), UserSelection(..))
+import Cards exposing (Card (..), Suit(..), Face(..))
+
+import MockUser exposing (..)
+
+all: Test
+all =
+    describe "MockUser"
+        [ describe "selectDeck"
+            [ test "should return UserTookLeft when card is in left deck" <|
+                \_ ->
+                    let
+                        card = Card Spades Ace
+                        game = { left = SlicedDeck [Card Spades Ace]
+                               , center = SlicedDeck [Card Hearts Ace]
+                               , right = SlicedDeck [Card Clubs Ace]
+                               }
+                    in
+                    selectDeck card game |> Expect.equal UserTookLeft
+            , test "should return UserTookRight when card is in right deck" <|
+                \_ ->
+                    let
+                        card = Card Clubs Ace
+                        game = { left = SlicedDeck [Card Spades Ace]
+                               , center = SlicedDeck [Card Hearts Ace]
+                               , right = SlicedDeck [Card Clubs Ace]
+                               }
+                    in
+                    selectDeck card game |> Expect.equal UserTookRight
+
+            , test "should return UserTookCenter when card is in center deck" <|
+                \_ ->
+                    let
+                        card = Card Hearts Ace
+                        game = { left = SlicedDeck [Card Spades Ace]
+                               , center = SlicedDeck [Card Hearts Ace]
+                               , right = SlicedDeck [Card Clubs Ace]
+                               }
+                    in
+                    selectDeck card game |> Expect.equal UserTookCenter
+            ]
+        ]


### PR DESCRIPTION
finally i finished the integration test. 

unfortunatelly it only works for a decksize of 21 cards.

So my assuption that on other decksizes like 9, 15, 27, 33, 39, 45, 51 it should be the card at index floor(decksize/2) is wrong.

Also the Result-issue is troublesome. Although, if we only support decksize 21 then lots of the datatype setup and its consequences can be removed...